### PR TITLE
fix: switch to amannn/action-semantic-pull-request

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -15,11 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: webiny/action-conventional-commits@v1.1.0
-      - uses: aslafy-z/conventional-pr-title-action@v3
-        with:
-          success-state: Title follows the specification.
-          failure-state: Title does not follow the specification.
-          context-name: conventional-pr-title
-          preset: conventional-changelog-conventionalcommits@latest
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.57.2


### PR DESCRIPTION
This change switches the conventional commit PR title check to use the `amannn/action-semantic-pull-request@v5` action since the current one we use is no longer maintained and in a broken state.